### PR TITLE
allow int32 as int property value

### DIFF
--- a/blockupgrader/schema.go
+++ b/blockupgrader/schema.go
@@ -110,6 +110,9 @@ func (s schema) applyPropertyFlattened(info schemaFlattenInfo, oldName string, p
 			embedKey = v
 		}
 	case "int":
+		if v, ok := val.(int32); ok {
+			val = int(v)
+		}
 		if v, ok := val.(int); ok {
 			embedKey = strconv.Itoa(v)
 		}


### PR DESCRIPTION
FlattenedPropertyType "int" needs to accept int32 since the nbt decoder outputs int32.